### PR TITLE
Add support for .NETStandard 2.0

### DIFF
--- a/src/HI.Sample/HI.Sample.csproj
+++ b/src/HI.Sample/HI.Sample.csproj
@@ -1,93 +1,30 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{915A4DE9-965A-4DD3-ADCA-490520E9CCDA}</ProjectGuid>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Nehta.VendorLibrary.HI.Sample</RootNamespace>
     <AssemblyName>Nehta.VendorLibrary.HI.Sample</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <OldToolsVersion>3.5</OldToolsVersion>
-    <UpgradeBackupLocation />
-    <TargetFrameworkProfile />
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Nehta.VendorLibrary.Common, Version=4.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nehta.VendorLibrary.Common.4.2.1\lib\net40\Nehta.VendorLibrary.Common.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core">
+
+  <!-- Conditionally obtain references for the .NET45 target -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <Reference Update="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
+	<Reference Include="System.Data.DataSetExtensions">
+		<RequiredTargetFramework>3.5</RequiredTargetFramework>
+	</Reference>
     <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
+	<Reference Include="System.Xml.Linq">
+		<RequiredTargetFramework>3.5</RequiredTargetFramework>
+	</Reference>
+	<Reference Include="System.Data" />
+	<Reference Include="System.Xml" />
   </ItemGroup>
+
   <ItemGroup>
-    <Compile Include="ConsumerCreateVerifiedIHIModClientSample.cs" />
-    <Compile Include="ConsumerCreateVerifiedIHIClientSample.cs" />
-    <Compile Include="ConsumerSearchIHIBatchSyncClientSample.cs" />
-    <Compile Include="ConsumerSearchIHIClientSample.cs" />
-    <Compile Include="ProviderReadProviderOrganisationClientSample.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ProviderBatchAsyncSearchForProviderIndividualClientSample.cs" />
-    <Compile Include="ProviderBatchAsyncSearchForProviderOrganisationClientSample.cs" />
-    <Compile Include="ProviderManageProviderOrganisationClientSample.cs" />
-    <Compile Include="ProviderManageProviderDirectoryEntryClientSample.cs" />
-    <Compile Include="ProviderReadReferenceDataClientSample.cs" />
-    <Compile Include="ProviderSearchForProviderIndividualClientSample.cs" />
-    <Compile Include="ProviderSearchForProviderOrganisationClientSample.cs" />
-    <Compile Include="ProviderSearchHIProviderDirectoryForIndividualClientSample.cs" />
-    <Compile Include="ProviderSearchHIProviderDirectoryForOrganisationClientSample.cs" />
+    <ProjectReference Include="..\HI\HI.csproj" />
+	  <ProjectReference Include="..\..\..\nehta-common-dotnet\src\Common\Common.csproj" /><!--Change to Nuget package version-->
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\HI\HI.csproj">
-      <Project>{1BD8F6A0-9D09-4E98-8B11-58EE42CAFB86}</Project>
-      <Name>HI</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/HI/HI.csproj
+++ b/src/HI/HI.csproj
@@ -1,156 +1,49 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{1BD8F6A0-9D09-4E98-8B11-58EE42CAFB86}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Nehta.VendorLibrary.HI</RootNamespace>
-    <AssemblyName>Nehta.VendorLibrary.HI</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <StartupObject>
-    </StartupObject>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <OldToolsVersion>3.5</OldToolsVersion>
-    <UpgradeBackupLocation />
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\Nehta.VendorLibrary.HI.xml</DocumentationFile>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="AutoMapper, Version=4.2.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.4.2.1\lib\net45\AutoMapper.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Nehta.VendorLibrary.Common, Version=4.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nehta.VendorLibrary.Common.4.2.1\lib\net40\Nehta.VendorLibrary.Common.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Runtime.Serialization">
-      <RequiredTargetFramework>3.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Security" />
-    <Reference Include="System.ServiceModel">
-      <RequiredTargetFramework>3.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ConsumerCreateVerifiedIHIModClient.cs" />
-    <Compile Include="GeneratedCode\R40-CreateVerifiedIHI-Mod.cs" />
-    <Compile Include="IConsumerCreateVerifiedIHIClient.cs" />
-    <Compile Include="IConsumerCreateVerifiedIHIModClient.cs" />
-    <Compile Include="IConsumerSearchIHIBatchAsyncClient.cs" />
-    <Compile Include="IConsumerSearchIHIBatchSyncClient.cs" />
-    <Compile Include="IConsumerSearchIHIClient.cs" />
-    <Compile Include="IProviderBatchAsyncSearchForProviderIndividualClient.cs" />
-    <Compile Include="IProviderBatchAsyncSearchForProviderOrganisationClient.cs" />
-    <Compile Include="IProviderManageProviderDirectoryEntryClient.cs" />
-    <Compile Include="IProviderManageProviderOrganisationClient.cs" />
-    <Compile Include="IProviderMatchProviderAdministrativeIndividualClient.cs" />
-    <Compile Include="IProviderReadProviderOrganisationClient.cs" />
-    <Compile Include="IProviderReadReferenceDataClient.cs" />
-    <Compile Include="IProviderSearchForProviderIndividualClient.cs" />
-    <Compile Include="IProviderSearchForProviderOrganisationClient.cs" />
-    <Compile Include="IProviderSearchHIProviderDirectoryForIndividualClient.cs" />
-    <Compile Include="IProviderSearchHIProviderDirectoryForOrganisationClient.cs" />
-    <Compile Include="ISoapClient.cs" />
-    <Compile Include="ProviderMatchProviderAdministrativeIndividualClient.cs" />
-    <Compile Include="ConsumerCreateVerifiedIHIClient.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="ConsumerSearchIHIBatchAsyncClient.cs" />
-    <Compile Include="ConsumerSearchIHIBatchSyncClient.cs" />
-    <Compile Include="GeneratedCode\R40-CreateVerifiedIHI.cs" />
-    <Compile Include="GeneratedCode\R7-ProviderMatchProviderAdministrativeIndividual.cs" />
-    <Compile Include="ProviderReadProviderOrganisationClient.cs" />
-    <Compile Include="GeneratedCode\R3-ConsumerSearchIHI.cs" />
-    <Compile Include="GeneratedCode\R3-ConsumerSearchIHIBatchAsync.cs" />
-    <Compile Include="GeneratedCode\R3-ConsumerSearchIHIBatchSync.cs" />
-    <Compile Include="GeneratedCode\R32-ProviderManageProviderDirectoryEntry.cs" />
-    <Compile Include="GeneratedCode\R32-ProviderManageProviderOrganisation.cs" />
-    <Compile Include="GeneratedCode\R32-ProviderReadProviderOrganisation.cs" />
-    <Compile Include="GeneratedCode\R32-ProviderReadReferenceData.cs" />
-    <Compile Include="GeneratedCode\R32-ProviderSearchHIProviderDirectoryForIndividual.cs" />
-    <Compile Include="GeneratedCode\R32-ProviderSearchHIProviderDirectoryForOrganisation.cs" />
-    <Compile Include="GeneratedCode\R50-ProviderSearchForProviderIndividual.cs" />
-    <Compile Include="GeneratedCode\R50-ProviderSearchForProviderOrganisation.cs" />
-    <Compile Include="GeneratedCode\R51-ProviderBatchAsyncSearchForProviderIndividual.cs" />
-    <Compile Include="GeneratedCode\R51-ProviderBatchAsyncSearchForProviderOrganisation.cs" />
-    <Compile Include="Helper\CommonSearchIHIExtensions.cs" />
-    <Compile Include="Helper\FaultHelper.cs" />
-    <Compile Include="Helper\HIEndpointProcessor.cs" />
-    <Compile Include="Helper\CommonSearchIHI.cs" />
-    <Compile Include="Helper\Utility.cs" />
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="ProviderBatchAsyncSearchForProviderIndividualClient.cs" />
-    <Compile Include="ProviderBatchAsyncSearchForProviderOrganisationClient.cs" />
-    <Compile Include="ProviderManageProviderDirectoryEntryClient.cs" />
-    <Compile Include="ProviderManageProviderOrganisationClient.cs" />
-    <Compile Include="ProviderReadReferenceDataClient.cs" />
-    <Compile Include="ProviderSearchForProviderIndividualClient.cs" />
-    <Compile Include="ProviderSearchForProviderOrganisationClient.cs" />
-    <Compile Include="ProviderSearchHIProviderDirectoryForIndividualClient.cs" />
-    <Compile Include="ConsumerSearchIHIClient.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ProviderSearchHIProviderDirectoryForOrganisationClient.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+		<OutputType>Library</OutputType>
+		<RootNamespace>Nehta.VendorLibrary.HI</RootNamespace>
+		<AssemblyName>Nehta.VendorLibrary.HI</AssemblyName>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	</PropertyGroup>
+
+	<!-- Conditionally obtain references for the .NET45 target -->
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+		<Reference Include="Microsoft.CSharp" />
+		<Reference Include="System" />
+		<Reference Include="System.Core">
+			<RequiredTargetFramework>3.5</RequiredTargetFramework>
+		</Reference>
+		<Reference Include="System.Drawing" />
+		<Reference Include="System.Runtime.Serialization">
+			<RequiredTargetFramework>3.0</RequiredTargetFramework>
+		</Reference>
+		<Reference Include="System.Security" />
+		<Reference Include="System.ServiceModel">
+			<RequiredTargetFramework>3.0</RequiredTargetFramework>
+		</Reference>
+		<Reference Include="System.Windows.Forms" />
+		<Reference Include="System.Xml.Linq">
+			<RequiredTargetFramework>3.5</RequiredTargetFramework>
+		</Reference>
+		<Reference Include="System.Data.DataSetExtensions">
+			<RequiredTargetFramework>3.5</RequiredTargetFramework>
+		</Reference>
+		<Reference Include="System.Data" />
+		<Reference Include="System.Xml" />
+	</ItemGroup>
+
+	<!-- Conditionally obtain references for the .NETStandard2.0 target -->
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+		<PackageReference Include="System.ServiceModel.Http" Version="4.9.0" />
+		<PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="AutoMapper" Version="7.0.1" />
+		<ProjectReference Include="..\..\..\nehta-common-dotnet\src\Common\Common.csproj" /><!--Change to Nuget package version-->
+	</ItemGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DocumentationFile>bin\Debug\$(TargetFramework)\Nehta.VendorLibrary.HI.xml</DocumentationFile>
+	</PropertyGroup>
 </Project>

--- a/src/HI/Helper/HIEndpointProcessor.cs
+++ b/src/HI/Helper/HIEndpointProcessor.cs
@@ -39,7 +39,11 @@ namespace Nehta.VendorLibrary.HI
             InspectorBehavior newBehavior = new InspectorBehavior(soapMessages, signingCertificate);
 
             // Add the behavior
+#if NET45
             endpoint.Behaviors.Add(newBehavior);
+#else
+            endpoint.EndpointBehaviors.Add(newBehavior);
+#endif
         }
 
         /// <summary>
@@ -296,7 +300,11 @@ namespace Nehta.VendorLibrary.HI
 
             public void ApplyClientBehavior(ServiceEndpoint endpoint, System.ServiceModel.Dispatcher.ClientRuntime clientRuntime)
             {
+#if NET45
                 clientRuntime.MessageInspectors.Add(new MessageInspector(soapMessages, signingCertificate));
+#else
+                clientRuntime.ClientMessageInspectors.Add(new MessageInspector(soapMessages, signingCertificate));
+#endif
             }
 
             public void ApplyDispatchBehavior(ServiceEndpoint endpoint, System.ServiceModel.Dispatcher.EndpointDispatcher endpointDispatcher)

--- a/src/HI/Helper/Utility.cs
+++ b/src/HI/Helper/Utility.cs
@@ -13,49 +13,56 @@ namespace Nehta.VendorLibrary.HI
     {
         public static bool MappingSet { get; set; }
 
+        public static IMapper Mapper { get; private set; }
+
         public static void SetUpMapping()
         {
             if (!MappingSet)
             {
-                // Set up mappings for async search
-                Mapper.CreateMap<CommonSearchIHIRequestType, Async.SearchIHIRequestType>();
-                Mapper.CreateMap<CommonAustralianPostalAddressType, Async.AustralianPostalAddressType>();
-                Mapper.CreateMap<CommonAustralianStreetAddressType, Async.AustralianStreetAddressType>();
-                Mapper.CreateMap<CommonCountryType, Async.CountryType>();
-                Mapper.CreateMap<CommonInternationalAddressType, Async.InternationalAddressType>();
-                Mapper.CreateMap<CommonAustralianUnstructuredStreetAddressType, Async.AustralianUnstructuredStreetAddressType>();
-                Mapper.CreateMap<CommonLevelGroupType, Async.LevelGroupType>();
-                Mapper.CreateMap<CommonLevelType, Async.LevelType>();
-                Mapper.CreateMap<CommonPostalDeliveryGroupType, Async.PostalDeliveryGroupType>();
-                Mapper.CreateMap<CommonPostalDeliveryType, Async.PostalDeliveryType>();
-                Mapper.CreateMap<CommonSearchIHI, Async.searchIHI>();
-                Mapper.CreateMap<CommonSexType, Async.SexType>();
-                Mapper.CreateMap<CommonStateType, Async.StateType>();
-                Mapper.CreateMap<CommonStreetSuffixType, Async.StreetSuffixType>();
-                Mapper.CreateMap<CommonStreetType, Async.StreetType>();
-                Mapper.CreateMap<CommonTrueFalseType, Async.TrueFalseType>();
-                Mapper.CreateMap<CommonUnitGroupType, Async.UnitGroupType>();
-                Mapper.CreateMap<CommonUnitType, Async.UnitType>();
+                var config = new MapperConfiguration(cfg =>
+                {
+                    // Set up mappings for async search
+                    cfg.CreateMap<CommonSearchIHIRequestType, Async.SearchIHIRequestType>();
+                    cfg.CreateMap<CommonAustralianPostalAddressType, Async.AustralianPostalAddressType>();
+                    cfg.CreateMap<CommonAustralianStreetAddressType, Async.AustralianStreetAddressType>();
+                    cfg.CreateMap<CommonCountryType, Async.CountryType>();
+                    cfg.CreateMap<CommonInternationalAddressType, Async.InternationalAddressType>();
+                    cfg.CreateMap<CommonAustralianUnstructuredStreetAddressType, Async.AustralianUnstructuredStreetAddressType>();
+                    cfg.CreateMap<CommonLevelGroupType, Async.LevelGroupType>();
+                    cfg.CreateMap<CommonLevelType, Async.LevelType>();
+                    cfg.CreateMap<CommonPostalDeliveryGroupType, Async.PostalDeliveryGroupType>();
+                    cfg.CreateMap<CommonPostalDeliveryType, Async.PostalDeliveryType>();
+                    cfg.CreateMap<CommonSearchIHI, Async.searchIHI>();
+                    cfg.CreateMap<CommonSexType, Async.SexType>();
+                    cfg.CreateMap<CommonStateType, Async.StateType>();
+                    cfg.CreateMap<CommonStreetSuffixType, Async.StreetSuffixType>();
+                    cfg.CreateMap<CommonStreetType, Async.StreetType>();
+                    cfg.CreateMap<CommonTrueFalseType, Async.TrueFalseType>();
+                    cfg.CreateMap<CommonUnitGroupType, Async.UnitGroupType>();
+                    cfg.CreateMap<CommonUnitType, Async.UnitType>();
 
-                // Set up mappings for sync search
-                Mapper.CreateMap<CommonSearchIHIRequestType, Sync.SearchIHIRequestType>();
-                Mapper.CreateMap<CommonAustralianPostalAddressType, Sync.AustralianPostalAddressType>();
-                Mapper.CreateMap<CommonAustralianStreetAddressType, Sync.AustralianStreetAddressType>();
-                Mapper.CreateMap<CommonCountryType, Sync.CountryType>();
-                Mapper.CreateMap<CommonInternationalAddressType, Sync.InternationalAddressType>();
-                Mapper.CreateMap<CommonAustralianUnstructuredStreetAddressType, Sync.AustralianUnstructuredStreetAddressType>();
-                Mapper.CreateMap<CommonLevelGroupType, Sync.LevelGroupType>();
-                Mapper.CreateMap<CommonLevelType, Sync.LevelType>();
-                Mapper.CreateMap<CommonPostalDeliveryGroupType, Sync.PostalDeliveryGroupType>();
-                Mapper.CreateMap<CommonPostalDeliveryType, Sync.PostalDeliveryType>();
-                Mapper.CreateMap<CommonSearchIHI, Sync.searchIHI>();
-                Mapper.CreateMap<CommonSexType, Sync.SexType>();
-                Mapper.CreateMap<CommonStateType, Sync.StateType>();
-                Mapper.CreateMap<CommonStreetSuffixType, Sync.StreetSuffixType>();
-                Mapper.CreateMap<CommonStreetType, Sync.StreetType>();
-                Mapper.CreateMap<CommonTrueFalseType, Sync.TrueFalseType>();
-                Mapper.CreateMap<CommonUnitGroupType, Sync.UnitGroupType>();
-                Mapper.CreateMap<CommonUnitType, Sync.UnitType>();
+                    // Set up mappings for sync search
+                    cfg.CreateMap<CommonSearchIHIRequestType, Sync.SearchIHIRequestType>();
+                    cfg.CreateMap<CommonAustralianPostalAddressType, Sync.AustralianPostalAddressType>();
+                    cfg.CreateMap<CommonAustralianStreetAddressType, Sync.AustralianStreetAddressType>();
+                    cfg.CreateMap<CommonCountryType, Sync.CountryType>();
+                    cfg.CreateMap<CommonInternationalAddressType, Sync.InternationalAddressType>();
+                    cfg.CreateMap<CommonAustralianUnstructuredStreetAddressType, Sync.AustralianUnstructuredStreetAddressType>();
+                    cfg.CreateMap<CommonLevelGroupType, Sync.LevelGroupType>();
+                    cfg.CreateMap<CommonLevelType, Sync.LevelType>();
+                    cfg.CreateMap<CommonPostalDeliveryGroupType, Sync.PostalDeliveryGroupType>();
+                    cfg.CreateMap<CommonPostalDeliveryType, Sync.PostalDeliveryType>();
+                    cfg.CreateMap<CommonSearchIHI, Sync.searchIHI>();
+                    cfg.CreateMap<CommonSexType, Sync.SexType>();
+                    cfg.CreateMap<CommonStateType, Sync.StateType>();
+                    cfg.CreateMap<CommonStreetSuffixType, Sync.StreetSuffixType>();
+                    cfg.CreateMap<CommonStreetType, Sync.StreetType>();
+                    cfg.CreateMap<CommonTrueFalseType, Sync.TrueFalseType>();
+                    cfg.CreateMap<CommonUnitGroupType, Sync.UnitGroupType>();
+                    cfg.CreateMap<CommonUnitType, Sync.UnitType>();
+                });
+
+                Mapper = new Mapper(config);
             }
         }
     }


### PR DESCRIPTION
Depends on https://github.com/AuDigitalHealth/nehta-common-dotnet/pull/2

TO DO
Change `<ProjectReference Include="..\..\..\nehta-common-dotnet\src\Common\Common.csproj" /><!--Change to Nuget package version-->` to the Nuget package version

Problem statement
Currently the HIS and MHR libraries only work on .NET Full Framework. Microsoft have stopped developing .NET Full Framework and .NET Core (now called .NET 5 and .NET 6) is the future https://devblogs.microsoft.com/dotnet/net-core-is-the-future-of-net/

This PR adds support for .NET Standard 2.0
.NET Standard is Microsoft's recommended approach for library developers as it allows your library to run on the greatest range of workloads: .NET Full Framework, .NET Core and .NET 5 & 6
https://docs.microsoft.com/en-us/dotnet/standard/class-libraries and https://docs.microsoft.com/en-us/dotnet/standard/net-standard

I've gone with the multi targeting approach https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting as I wasn't sure if you still need to be able to use .NET Framework 4.0. I'd seriously consider only supporting .NET Standard as these old versions of full framework are no longer supported by Microsoft

### Definition of Done

* [ ] Code has been peer reviewed
* [ ] Test coverage has been maintained or improved
* [ ] All tests pass within CI
* [ ] README is up to date

